### PR TITLE
Fixed duplicate color bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -395,10 +395,10 @@ HTTP_RGB.prototype = {
         this.log('Caching Hue as %s ...', level);
         this.cache.hue = level;
         if (this.cacheUpdated) {
-          this._setRGB(callback);
+            this._setRGB(callback);
         } else {
-          this.cacheUpdated = true;
-          callback();
+            this.cacheUpdated = true;
+            callback();
         }
     },
 
@@ -451,10 +451,10 @@ HTTP_RGB.prototype = {
         this.log('Caching Saturation as %s ...', level);
         this.cache.saturation = level;
         if (this.cacheUpdated) {
-          this._setRGB(callback);
+            this._setRGB(callback);
         } else {
-          this.cacheUpdated = true;
-          callback();
+            this.cacheUpdated = true;
+            callback();
         }
     },
 

--- a/index.js
+++ b/index.js
@@ -57,6 +57,7 @@ function HTTP_RGB(log, config) {
 
     // Local caching of HSB color space for RGB callback
     this.cache = {};
+    this.cacheUpdated = false;
 
     // Handle brightness
     if (typeof config.brightness === 'object') {
@@ -393,8 +394,12 @@ HTTP_RGB.prototype = {
         }
         this.log('Caching Hue as %s ...', level);
         this.cache.hue = level;
-
-        this._setRGB(callback);
+        if (this.cacheUpdated) {
+          this._setRGB(callback);
+        } else {
+          this.cacheUpdated = true;
+          callback();
+        }
     },
 
     /**
@@ -445,9 +450,12 @@ HTTP_RGB.prototype = {
         }
         this.log('Caching Saturation as %s ...', level);
         this.cache.saturation = level;
-
-        //this._setRGB(callback);
-        callback();
+        if (this.cacheUpdated) {
+          this._setRGB(callback);
+        } else {
+          this.cacheUpdated = true;
+          callback();
+        }
     },
 
     /**
@@ -462,6 +470,7 @@ HTTP_RGB.prototype = {
         var b = this._decToHex(rgb.b);
 
         var url = this.color.set_url.replace('%s', r + g + b);
+        this.cacheUpdated = false;
 
         this.log('_setRGB converting H:%s S:%s B:%s to RGB:%s ...', this.cache.hue, this.cache.saturation, this.cache.brightness, r + g + b);
 

--- a/index.js
+++ b/index.js
@@ -446,7 +446,8 @@ HTTP_RGB.prototype = {
         this.log('Caching Saturation as %s ...', level);
         this.cache.saturation = level;
 
-        this._setRGB(callback);
+        //this._setRGB(callback);
+        callback();
     },
 
     /**


### PR DESCRIPTION
When setting the color, both `setSaturation` and `setHue` called `_setRGB` asynchronously, so when the calls were executed in the wrong order it caused the wrong color to be set. Now it checks whether the other function has run before, so `_setRGB` only is called once.

Edit: This fixes issue #8 