### PR TITLE
Notification push support, bodyRegEx support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+## v2.0.1
+* Fix InformationService reporting to cirrectly report manufacturer, model and firmware version.
+* Support for homebridge-http-notification-server to support single devices with multiple light states,
+* Support for `status.bodyRegEx` to allow for devices which return  for example JSON as a result.
+
 ## v2.0.0
 
 * `service` is required in config stanza.

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ callback for getting and setting the following characteristics to Homekit:
 
 The following is an overview of the structure of your HTTP-RGB accessory.
 
-Both `powerOn` and `powerOff` can either be a `string` or an `object`.  If a
-`string` is provided it is filled in as the `url` and the `body` will be blank.
-Most devices will be ok with the `string` option.
+All `powerOn`, `powerOff` and `status` can either be a `string` or an `object`.
+If a `string` is provided it is filled in as the `url` and the `body` will be
+blank. Most devices will be ok with the `string` option.
 
 The purpose of `powerOff`/`powerOn` for an RGB light is not to physically power
 or de-power the device (as then how would it respond to further commands?), but
@@ -55,7 +55,7 @@ can only read the settings, you may not change them.
         "sendImmediately": string-optional,
 
         "switch": {
-            "status": url-optional,
+            "status": string-or-object-optional,
             "powerOn": string-or-object,
             "powerOff": {
                 url: string,
@@ -176,10 +176,14 @@ remove the brightness component from the config.
 
 # Interfacing
 
-All the `.status` urls expect a 200 HTTP status code and a body of a single
+`switch.status` Can be configured to parse the body to determine the switch
+status. When the specified `switch.status.statusRegEx` matches the body the
+switch is considered to be in the on status. If this parameter is left out
+`switch.status` expects `0` for Off, and `1` for On.
+
+All other `.status` urls expect a 200 HTTP status code and a body of a single
 string with no HTML markup.
 
-* `switch.status` expects `0` for Off, and `1` for On.
 * `brightness.status` expects a number from 0 to 100.
 * `color.status` expects a 6-digit hexidemial number.
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ can either be a `string` or an `object`.  If it is a `string`, it is filled in
 as the `status` and the other fields are left blank. When this is the case, you
 can only read the settings, you may not change them.
 
+This accessory supports push notification from the physical device via 
+'homebridge-http-notification-server'. This allows the device to modify the
+switch's status by pushing the new status instead of Homebridge pulling it.
+This can be realized by supplying the `notificationID`.
+To get more details about the push configuration have a look at the 
+[README](https://github.com/Supereg/homebridge-http-notification-server).
+
 `service` is one of `['Light', 'Switch']`.
 
 
@@ -56,6 +63,8 @@ can only read the settings, you may not change them.
 
         "switch": {
             "status": string-or-object-optional,
+            "notificationID": string-optional,
+            notificationPassword: string-optional,
             "powerOn": string-or-object,
             "powerOff": {
                 url: string,
@@ -175,13 +184,14 @@ remove the brightness component from the config.
 
 
 # Interfacing
+All `.status` urls expect a 200 HTTP status code.
 
 `switch.status` Can be configured to parse the body to determine the switch
-status. When the specified `switch.status.statusRegEx` matches the body the
+status. When the specified `switch.status.bodyRegEx` matches the body the
 switch is considered to be in the on status. If this parameter is left out
 `switch.status` expects `0` for Off, and `1` for On.
 
-All other `.status` urls expect a 200 HTTP status code and a body of a single
+All other `.status` urls expect a body of a single
 string with no HTML markup.
 
 * `brightness.status` expects a number from 0 to 100.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This accessory supports push notification from the physical device via
 'homebridge-http-notification-server'. This allows the device to modify the
 switch's status by pushing the new status instead of Homebridge pulling it.
 This can be realized by supplying the `notificationID`.
-To get more details about the push configuration have a look at the 
+To get more details about the push configuration have a look at this 
 [README](https://github.com/Supereg/homebridge-http-notification-server).
 
 `service` is one of `['Light', 'Switch']`.
@@ -64,7 +64,7 @@ To get more details about the push configuration have a look at the
         "switch": {
             "status": string-or-object-optional,
             "notificationID": string-optional,
-            notificationPassword: string-optional,
+            "notificationPassword": string-optional,
             "powerOn": string-or-object,
             "powerOff": {
                 url: string,
@@ -182,6 +182,25 @@ This normally will not occur, however, you may not want your application to
 display a "brightness" slider to the user.  In this case, you will want to
 remove the brightness component from the config.
 
+### Regular expression on-body matching
+
+    "accessories": [
+        {
+            "accessory": "HTTP-RGB",
+            "name": "JSON body matching",
+            "service": "Light",
+
+            "switch": {
+                "status": {
+                    "url": "http://localhost/api/v1/status",
+                    "bodyRegEx": "\"switch\":\s*\"on\""
+                }
+                "powerOn": "http://localhost/api/v1/on",
+                "powerOff": "http://localhost/api/v1/off"
+            }
+            }
+        }
+    ]
 
 # Interfacing
 All `.status` urls expect a 200 HTTP status code.

--- a/index.js
+++ b/index.js
@@ -71,14 +71,14 @@ function HTTP_RGB(log, config) {
             this.switch.powerOff.set_url   = config.switch.powerOff;
         }
         
-        // Register notification server
+        // Register notification server.
         api.on('didFinishLaunching', function() {
-           // check if notificationRegistration is set, if not 'notificationRegistration' is probably not installed on the system
+           // Check if notificationRegistration is set, if not 'notificationRegistration' is probably not installed on the system.
            if (api.notificationRegistration && typeof api.notificationRegistration === "function") {
                try {
-                   api.notificationRegistration(config.switch.notificationID, this.handleNotification.bind(this), "top-secret-password");
+                   api.notificationRegistration(config.switch.notificationID, this.handleNotification.bind(this), config.switch.notificationPassword);
                } catch (error) {
-                   // notificationID is already taken
+                   // notificationID is already taken.
                }
            }
         }.bind(this));

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var Service, Characteristic;
 var request = require('request');
+let api
 
 /**
  * @module homebridge
@@ -10,6 +11,7 @@ module.exports = function(homebridge){
     Service = homebridge.hap.Service;
     Characteristic = homebridge.hap.Characteristic;
     homebridge.registerAccessory('homebridge-better-http-rgb', 'HTTP-RGB', HTTP_RGB);
+    api = homebridge;
 };
 
 /**
@@ -68,6 +70,19 @@ function HTTP_RGB(log, config) {
         } else {
             this.switch.powerOff.set_url   = config.switch.powerOff;
         }
+        
+        // Register notification server
+        api.on('didFinishLaunching', function() {
+           // check if notificationRegistration is set, if not 'notificationRegistration' is probably not installed on the system
+           if (api.notificationRegistration && typeof api.notificationRegistration === "function") {
+               try {
+                   api.notificationRegistration(config.switch.notificationID, this.handleNotification.bind(this), "top-secret-password");
+               } catch (error) {
+                   // notificationID is already taken
+               }
+           }
+        }.bind(this));
+    
     }
 
     // Local caching of HSB color space for RGB callback

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ function HTTP_RGB(log, config) {
     this.password                      = config.password                  || '';
 
     // Handle the basic on/off
-    this.switch = { powerOn: {}, powerOff: {} };
+    this.switch = { powerOn: {}, powerOff: {}, status: {} };
     if (typeof config.switch === 'object') {
 
         this.switch.status.bodyRegEx   = new RegExp("1");
@@ -47,7 +47,7 @@ function HTTP_RGB(log, config) {
                this.switch.status.bodyRegEx = new RegExp(config.switch.status.bodyRegEx);
             }
             else {
-               this.log.warn("Property 'switch.status.bodyRegEx' was given in an unsupported type. Using default one!");
+               this.log.warn("Property 'switch.status.bodyRegEx' was provided in an unsupported type. Using default one!");
             }
         } else {
             this.switch.status.url         = config.switch.status;

--- a/index.js
+++ b/index.js
@@ -73,8 +73,10 @@ function HTTP_RGB(log, config) {
         
         // Register notification server.
         api.on('didFinishLaunching', function() {
-           // Check if notificationRegistration is set, if not 'notificationRegistration' is probably not installed on the system.
-           if (api.notificationRegistration && typeof api.notificationRegistration === "function") {
+           // Check if notificationRegistration is set and user specified notificationID.
+           // if not 'notificationRegistration' is probably not installed on the system.
+           if (api.notificationRegistration && typeof api.notificationRegistration === "function" &&
+               config.switch.notificationID) {
                try {
                    api.notificationRegistration(config.switch.notificationID, this.handleNotification.bind(this), config.switch.notificationPassword);
                } catch (error) {

--- a/index.js
+++ b/index.js
@@ -36,7 +36,23 @@ function HTTP_RGB(log, config) {
     // Handle the basic on/off
     this.switch = { powerOn: {}, powerOff: {} };
     if (typeof config.switch === 'object') {
-        this.switch.status                 = config.switch.status;
+
+        this.switch.status.bodyRegEx   = new RegExp("1");
+        // Intelligently handle if config.switch.status is an object or string.
+        if (typeof config.switch.status === 'object') {
+            this.switch.status.url         = config.switch.status.url;
+
+            // Verify type of body regular expression parameter.
+            if (typeof config.switch.status.bodyRegEx === "string") {
+               this.switch.status.bodyRegEx = new RegExp(config.switch.status.bodyRegEx);
+            }
+            else {
+               this.log.warn("Property 'switch.status.bodyRegEx' was given in an unsupported type. Using default one!");
+
+            }
+        } else {
+            this.switch.status.url         = config.switch.status;
+        }
 
         // Intelligently handle if config.switch.powerOn is an object or string.
         if (typeof config.switch.powerOn === 'object') {
@@ -171,7 +187,7 @@ HTTP_RGB.prototype = {
                HomeKit-compatible devices can be.
             */
             /*
-            
+
             case 'Lock':
                 var lockService = new Service.LockMechanism(this.name);
 
@@ -248,7 +264,7 @@ HTTP_RGB.prototype = {
                 this.log('getPowerState() failed: %s', error.message);
                 callback(error);
             } else {
-                var powerOn = parseInt(responseBody) > 0;
+                var powerOn = this.switch.status.bodyRegEx.test(responseBody)
                 this.log('power is currently %s', powerOn ? 'ON' : 'OFF');
                 callback(null, powerOn);
             }

--- a/index.js
+++ b/index.js
@@ -48,7 +48,6 @@ function HTTP_RGB(log, config) {
             }
             else {
                this.log.warn("Property 'switch.status.bodyRegEx' was given in an unsupported type. Using default one!");
-
             }
         } else {
             this.switch.status.url         = config.switch.status;

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
   "contributors": [
     {
       "name": "Adrian Rudman"
+    },
+    {
+      "name": "Sander van Woensel"
     }
   ],
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-better-http-rgb",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Homebridge plugin to control a web-based RGB device.",
   "license": "ISC",
   "keywords": [


### PR DESCRIPTION
I've added support for the homebridge-http-notification-server push notifications. This allows to have one device with multiple "light" states or effects. Aside this, it allows the device to push the correct state to HomeKit based on autonomous changes initiated by the device itself or manual changes not routed via HomeKit.

I've also added the possibility to specify a status regular expression for devices which return something else then just a "1" or "0" for the power status. I can understand if you think this doesn't align with the original design philosophy of homebridge-better-http-rgb (e.g. to keep it simple).

Along the way I noticed there was a small mistake in the way it attempted to report InformationService information towards HomeKit. This is now functioning correctly.